### PR TITLE
Disable the PHP engine when serving files from /public

### DIFF
--- a/volumes/config/apache.pkp.conf
+++ b/volumes/config/apache.pkp.conf
@@ -16,6 +16,10 @@
 		RewriteRule ^(.*)$ index.php/$1 [QSA,L]
 	</Directory>
 
+	<Directory /var/www/html/public>
+		php_flag engine off
+	</Directory>
+
 	# ErrorLog  /var/log/apache2/error.log  
 	# CustomLog  /var/log/apache2/access.log combined
 
@@ -57,6 +61,10 @@
 		RewriteCond %{REQUEST_FILENAME} !-d 
 		RewriteCond %{REQUEST_FILENAME} !-f 
 		RewriteRule ^(.*)$ index.php/$1 [QSA,L]
+	</Directory>
+
+	<Directory /var/www/html/public>
+		php_flag engine off
 	</Directory>
 
 	# ErrorLog  /var/log/apache2/error.log  


### PR DESCRIPTION
Best I can tell, the docker-compose.yml file included here mounts files in the public/ folder off of the document root. For added security, we should prevent PHP from executing when it sits in that directory.