### PR TITLE
Fix pkp-cli-install for OJS 3.5

### DIFF
--- a/templates/pkp/root/usr/local/bin/pkp-cli-install
+++ b/templates/pkp/root/usr/local/bin/pkp-cli-install
@@ -30,10 +30,10 @@ echo "127.0.0.1 ${SERVERNAME}" >> /etc/hosts 2>/dev/null || true
   curl -sk -b "$COOKIE_FILE" \
     "$POST_URL" \
     --data-urlencode "installing=0" \
-    --data-urlencode "adminUsername=admin" \
-    --data-urlencode "adminPassword=admin" \
-    --data-urlencode "adminPassword2=admin" \
-    --data-urlencode "adminEmail=admin@${SERVERNAME}.org" \
+    --data-urlencode "adminUsername=${PKP_ADMIN_USER:-admin}" \
+    --data-urlencode "adminPassword=${PKP_ADMIN_PASSWORD:-admin}" \
+    --data-urlencode "adminPassword2=${PKP_ADMIN_PASSWORD:-admin}" \
+    --data-urlencode "adminEmail=${PKP_ADMIN_EMAIL:-admin@${SERVERNAME}.org}" \
     --data-urlencode "locale=en" \
     --data-urlencode "additionalLocales[]=en" \
     --data-urlencode "clientCharset=utf-8" \

--- a/templates/pkp/root/usr/local/bin/pkp-cli-install
+++ b/templates/pkp/root/usr/local/bin/pkp-cli-install
@@ -1,11 +1,61 @@
 #!/bin/sh
 
 echo "[PKP CLI Install] First time running this container, preparing..."
-echo "127.0.0.1 ${SERVERNAME}" >> /etc/hosts
+echo "127.0.0.1 ${SERVERNAME}" >> /etc/hosts 2>/dev/null || true
 
-echo "[PKP CLI Install] Calling the install using pre-defined variables..."
+# Run install in the background so that pkp-pre-start can return and Apache
+# can start — the curl needs a running web server to POST to.
+(
+  COOKIE_FILE=$(mktemp)
+  TIMEZONE="${TZ:-UTC}"
+  INSTALL_URL="https://localhost/index/en/install"
+  POST_URL="https://localhost/index/en/install/install"
 
-# PKP don't have a cli installer, but we can use a curl call instead:
-curl "https://${SERVERNAME}/index/install/install" --data "installing=0&adminUsername=admin&adminPassword=admin&adminPassword2=admin&adminEmail=admin%40${SERVERNAME}.org&locale=en_US&additionalLocales%5B%5D=en_US&clientCharset=utf-8&connectionCharset=utf8&databaseCharset=utf8&filesDir=%2Fvar%2Fwww%2Ffiles&databaseDriver=mysql&databaseHost=${PKP_DB_HOST}&databaseUsername=${PKP_DB_USER}&databasePassword=${PKP_DB_PASSWORD}&databaseName=${PKP_DB_NAME}&oaiRepositoryId=${SERVERNAME}&enableBeacon=0" --compressed
+  echo "[PKP CLI Install] Waiting for web server..."
+  for i in $(seq 1 30); do
+    if curl -sk -o /dev/null "$INSTALL_URL" 2>/dev/null; then
+      break
+    fi
+    sleep 2
+  done
 
-echo "[PKP CLI Install] DONE!"
+  echo "[PKP CLI Install] Calling the install using pre-defined variables..."
+
+  # OJS 3.5+ requires a valid session cookie, so fetch the install page first.
+  curl -sk -c "$COOKIE_FILE" "$INSTALL_URL" -o /dev/null
+
+  # PKP don't have a cli installer, but we can use a curl call instead.
+  # POST directly to the locale-prefixed URL to avoid a 302 redirect
+  # (which would convert POST to GET and lose form data).
+  curl -sk -b "$COOKIE_FILE" \
+    "$POST_URL" \
+    --data-urlencode "installing=0" \
+    --data-urlencode "adminUsername=admin" \
+    --data-urlencode "adminPassword=admin" \
+    --data-urlencode "adminPassword2=admin" \
+    --data-urlencode "adminEmail=admin@${SERVERNAME}.org" \
+    --data-urlencode "locale=en" \
+    --data-urlencode "additionalLocales[]=en" \
+    --data-urlencode "clientCharset=utf-8" \
+    --data-urlencode "connectionCharset=utf8" \
+    --data-urlencode "databaseCharset=utf8" \
+    --data-urlencode "filesDir=/var/www/files" \
+    --data-urlencode "databaseDriver=mysqli" \
+    --data-urlencode "databaseHost=${PKP_DB_HOST}" \
+    --data-urlencode "databaseUsername=${PKP_DB_USER}" \
+    --data-urlencode "databasePassword=${PKP_DB_PASSWORD}" \
+    --data-urlencode "databaseName=${PKP_DB_NAME}" \
+    --data-urlencode "oaiRepositoryId=${SERVERNAME}" \
+    --data-urlencode "enableBeacon=0" \
+    --data-urlencode "timeZone=${TIMEZONE}" \
+    --compressed -o /dev/null
+
+  rm -f "$COOKIE_FILE"
+
+  # Verify that the install succeeded.
+  if grep -q "installed = On" /var/www/html/config.inc.php 2>/dev/null; then
+    echo "[PKP CLI Install] DONE!"
+  else
+    echo "[PKP CLI Install] ERROR: install did not complete — check container logs." >&2
+  fi
+) &

--- a/templates/pkp/root/usr/local/bin/pkp-start
+++ b/templates/pkp/root/usr/local/bin/pkp-start
@@ -26,7 +26,3 @@ echo "--> [PKP Start] Started apache..."
 # ln -sf /dev/stdout /var/log/apache2/ssl_access.log \
 #     && ln -sf /dev/stderr /var/log/apache2/ssl_error.log
 
-if [ "${PKP_CLI_INSTALL}" = "1" ] &&
-    grep -q 'installed = Off' "${PKP_CONF}" ; then
-    /usr/local/bin/pkp-cli-install
-fi


### PR DESCRIPTION
## Summary

`PKP_CLI_INSTALL=1` fails silently on OJS 3.5 images (#26). This patch fixes all the root causes in `pkp-cli-install`:

- **Timing** — the script runs before Apache starts, so curl has nowhere to connect. Fixed by backgrounding the install with a wait loop.
- **Session cookie** — OJS 3.5 rejects the POST with a 302 if there's no session. Fixed by fetching the install page first (`curl -c`) then POSTing with the cookie (`curl -b`).
- **302 redirect loses POST data** — `/index/install/install` redirects to `/index/en/install/install`, converting POST→GET. Fixed by POSTing directly to the locale-prefixed URL.
- **Locale codes changed** — OJS 3.5 uses `en` not `en_US`.
- **Database driver changed** — OJS 3.5 uses `mysqli` not `mysql`.
- **Missing `timeZone` field** — required by OJS 3.5. Reads `$TZ` env var, defaults to `UTC`.
- **Self-signed certs** — added `-sk` flags since `pkp-pre-start` generates a self-signed certificate.
- **Post-install verification** — checks `installed = On` in config and reports an error instead of always printing `DONE!`.
- **Configurable admin credentials** — admin username, password, and email are now read from `PKP_ADMIN_USER`, `PKP_ADMIN_PASSWORD`, and `PKP_ADMIN_EMAIL` env vars (defaults to `admin`/`admin` for backward compatibility). Previously hardcoded.

Also removes the duplicate install check from `pkp-start` — it ran after `apache2-foreground` which is the container's foreground process, so it was dead code (only reached on container shutdown).

## New environment variables

| Variable | Default | Description |
|---|---|---|
| `TZ` | `UTC` | Timezone for OJS installation |
| `PKP_ADMIN_USER` | `admin` | Admin username |
| `PKP_ADMIN_PASSWORD` | `admin` | Admin password |
| `PKP_ADMIN_EMAIL` | `admin@${SERVERNAME}.org` | Admin email address |

## Test plan

- [x] Start fresh `pkpofficial/ojs:3_5_0-3` with `PKP_CLI_INSTALL=1` and the fixed script mounted in
- [x] Verify `installed = On` in `config.inc.php`
- [x] Verify container logs show `[PKP CLI Install] DONE!` (not ERROR)
- [x] Verify OJS serves pages on HTTPS (not the install wizard)
- [x] Verify custom admin credentials (`PKP_ADMIN_USER`, `PKP_ADMIN_PASSWORD`, `PKP_ADMIN_EMAIL`) are applied — confirmed via DB query

## Notes

The `databaseDriver` change from `mysql` to `mysqli` reflects what OJS 3.5's install form actually accepts (`mysqli`, `postgres9`, `mariadb`). Older OJS versions may need a different value — happy to discuss backward compatibility.

## LLM Generated, Human Reviewed

This code was generated with [Claude Code](https://claude.ai/claude-code) (Anthropic, Claude Opus 4.6). Development was closely overseen by a human with particular attention to security and reliability — every architectural decision, configuration choice, and debugging session was directed and verified by a human throughout. The code and test results were reviewed and tested by the author beyond the LLM.

Fixes #26